### PR TITLE
Update DockerHub links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For convenience, Lagoon also includes client libraries for interacting with its 
 
 ### Docker
 
-Pre-built docker images containing the lagoon server and CLI may be found on [DockerHub](TODO). Simply pull one of the images there and follow the [configuration guide](docs/CONFIG.md) to get started.
+Pre-built docker images containing the lagoon server and CLI may be found on [DockerHub](https://hub.docker.com/u/tweag). Simply pull one of the images there and follow the [configuration guide](docs/CONFIG.md) to get started.
 
 ### From source
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # docker
 
-Since this project uses nix for packaging, Docker images are generated using nix's dockertools module and are defined as a nix expression in [docker.nix](docker.nix) instead of a traditional Dockerfile.  Docker images for the lagoon server and command line client are available at [TODO - DockerHubLink]().
+Since this project uses nix for packaging, Docker images are generated using nix's dockertools module and are defined as a nix expression in [docker.nix](docker.nix) instead of a traditional Dockerfile.  Docker images for the [lagoon server](https://hub.docker.com/r/tweag/lagoon-server) and [command line client](https://hub.docker.com/r/tweag/lagoon-client) are available on DockerHub.
 
 ### Example
 A [docker-compose file](./docker-compose.yaml) which spins up a local lagoon server is included in this directory along with example config files in [examples/](./examples/).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -28,10 +28,9 @@ docker exec lagoon-postgres psql --username postgres -w --dbname postgres --comm
 ```
 
 ### Lagoon backend initialization
-Now that the database is running, we can initialize the lagoon backend. For this example, we'll be using the docker images provided at [TODO](). You can
+Now that the database is running, we can initialize the lagoon backend. For this example, we'll be using the docker images provided on the [Tweag DockerHub organization](https://hub.docker.com/u/tweag). You can
 also follow along using the lagoon-server executable built with nix (see the [README]((../README.md)) for more details).
 
-TODO: confirm this image path
 ```
 docker run --rm tweag/lagoon-server --pghost localhost --pgport 5432 --pguser postgres --pgpassword mysecretpassword init-db --db-admin-pass lagoonpassword
 ```


### PR DESCRIPTION
Updated DockerHub links in documentation to point to the actual
DockerHub org/repository instead of placeholders.